### PR TITLE
docs: Add lossless encoding tip

### DIFF
--- a/content/docs/modules/videorecorder.rst
+++ b/content/docs/modules/videorecorder.rst
@@ -34,7 +34,9 @@ That depends on what kind of data you record. But here is a general rule of thum
 
 {{< callout type="info" >}}
 Remember to perform a test recording and play with the *Quality* or *Bitrate* settings for lossy codecs
-to get the optimal result: A high-quality recording at the lowest-possible filesize.
+to get the optimal result: A high-quality recording at the lowest-possible filesize. If possible, and your chosen codec
+supports it, start with a lossless recording to determine the baseline filesize. For favorable image noise levels
+and image dynamics, lossless encoding can provide enough compression.
 {{< /callout >}}
 
 


### PR DESCRIPTION
I realized that my video size was massive while using a lossless codec, which was counter intuitive at first. Then I tried lossless and it became tiny by comparison (~1-2GB vs ~40MB).

After a little thinking, one understands what is going on, the constant quality forced an unnecessarily large file size allocation.

While encoding (lossy) video does require playing around with the settings, I am suggesting this documentation tip because the default encoder settings create fairly large files in my case, while lossless AV1 is actually acceptable.

Related thought: Should all codecs settings default to lossless instead of lossy? I would say it is safer from a scientific and data integrity perspective to record accurate data, be default. If the file size becomes a problem they will be forced to think and experiment with the lossy settings. Currently the default settings can lead to massive files (and lossy data?). The effectiveness of the modern encoders might favor a lossless default too.